### PR TITLE
Fixing README.md spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Example:
 
 ```ruby
 client = Google::APIClient.new
-urlshortener = client.discovered_api('urlshortner')
+urlshortener = client.discovered_api('urlshortener')
 
 batch = Google::APIClient::BatchRequest.new do |result|
     puts result.data


### PR DESCRIPTION
The batching example had 'urlshortener' misspelled. If someone was to copy and paste the example to test it wouldn't work.