### PR TITLE
Get rid of require_relative

### DIFF
--- a/lib/google/api_client/auth/file_storage.rb
+++ b/lib/google/api_client/auth/file_storage.rb
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 require 'signet/oauth_2/client'
-require_relative 'storage'
-require_relative 'storages/file_store'
+require File.join(File.expand_path(File.dirname(__FILE__)), 'storage')
+require File.join(File.expand_path(File.dirname(__FILE__)), 'storages', 'file_store')
+
 
 module Google
   class APIClient


### PR DESCRIPTION
Hello!
I have used code from README:
```ruby
require 'google/api_client'
require 'google/api_client/client_secrets'
require 'google/api_client/auth/installed_app'
```
but it raises warnings:
```
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.5/lib/ruby/gems/2.1.0/gems/google-api-client-0.8.2/lib/google/api_client/auth/storage.rb:26: warning: already initialized constant Google::APIClient::Storage::AUTHORIZATION_URI
/usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/google-api-client-0.8.2/lib/google/api_client/auth/storage.rb:26: warning: previous definition of AUTHORIZATION_URI was here
/usr/local/Cellar/rbenv/0.4.0/versions/2.1.5/lib/ruby/gems/2.1.0/gems/google-api-client-0.8.2/lib/google/api_client/auth/storage.rb:27: warning: already initialized constant Google::APIClient::Storage::TOKEN_CREDENTIAL_URI
/usr/local/opt/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/google-api-client-0.8.2/lib/google/api_client/auth/storage.rb:27: warning: previous definition of TOKEN_CREDENTIAL_URI was here
```
`require_relative` and `require` are generates not equal paths, so `storage.rb` is required twice.