### PR TITLE
Fix warnings

### DIFF
--- a/lib/google/api_client.rb
+++ b/lib/google/api_client.rb
@@ -490,7 +490,7 @@ module Google
       else
         check_cached_certs = lambda do
           valid = false
-          for key, cert in @certificates
+          for _key, cert in @certificates
             begin
               self.authorization.decoded_id_token(cert.public_key)
               valid = true

--- a/lib/google/api_client/auth/key_utils.rb
+++ b/lib/google/api_client/auth/key_utils.rb
@@ -25,44 +25,44 @@ module Google
       #
       # @param [String] keyfile
       #    Path of the PKCS12 file to load. If not a path to an actual file,
-      #    assumes the string is the content of the file itself. 
+      #    assumes the string is the content of the file itself.
       # @param [String] passphrase
       #   Passphrase for unlocking the private key
       #
       # @return [OpenSSL::PKey] The private key for signing assertions.
       def self.load_from_pkcs12(keyfile, passphrase)
-        load_key(keyfile, passphrase) do |content, passphrase| 
-          OpenSSL::PKCS12.new(content, passphrase).key
+        load_key(keyfile, passphrase) do |content, pass_phrase|
+          OpenSSL::PKCS12.new(content, pass_phrase).key
         end
       end
-      
+
 
       ##
       # Loads a key from a PEM file.
       #
       # @param [String] keyfile
       #    Path of the PEM file to load. If not a path to an actual file,
-      #    assumes the string is the content of the file itself. 
+      #    assumes the string is the content of the file itself.
       # @param [String] passphrase
       #   Passphrase for unlocking the private key
       #
       # @return [OpenSSL::PKey] The private key for signing assertions.
       #
       def self.load_from_pem(keyfile, passphrase)
-        load_key(keyfile, passphrase) do | content, passphrase|
-          OpenSSL::PKey::RSA.new(content, passphrase)
+        load_key(keyfile, passphrase) do | content, pass_phrase|
+          OpenSSL::PKey::RSA.new(content, pass_phrase)
         end
       end
 
       private
-      
+
       ##
       # Helper for loading keys from file or memory. Accepts a block
       # to handle the specific file format.
       #
       # @param [String] keyfile
       #    Path of thefile to load. If not a path to an actual file,
-      #    assumes the string is the content of the file itself. 
+      #    assumes the string is the content of the file itself.
       # @param [String] passphrase
       #   Passphrase for unlocking the private key
       #
@@ -86,8 +86,8 @@ module Google
           block.call(content, passphrase)
         rescue OpenSSL::OpenSSLError
           raise ArgumentError.new("Invalid keyfile or passphrase")
-        end        
-      end  
+        end
+      end
     end
   end
 end

--- a/lib/google/api_client/auth/storage.rb
+++ b/lib/google/api_client/auth/storage.rb
@@ -38,6 +38,7 @@ module Google
       # @params [Object] Storage object
       def initialize(store)
         @store= store
+        @authorization = nil
       end
 
       ##

--- a/lib/google/api_client/batch.rb
+++ b/lib/google/api_client/batch.rb
@@ -87,6 +87,7 @@ module Google
       #   block to be called when result ready
       def initialize(options = {}, &block)
         @calls = []
+        @global_callback = nil
         @global_callback = block if block_given?
         @last_auto_id = 0
 

--- a/lib/google/api_client/request.rb
+++ b/lib/google/api_client/request.rb
@@ -27,7 +27,7 @@ module Google
     # Represents an API request.
     class Request
       include Google::APIClient::Logging
-      
+
       MULTIPART_BOUNDARY = "-----------RubyApiMultipartPost".freeze
 
       # @return [Hash] Request parameters
@@ -157,7 +157,7 @@ module Google
       # @return [Google::APIClient::Result]
       #   result of API request
       def send(connection, is_retry = false)
-        self.body.rewind if is_retry && self.body.respond_to?(:rewind)          
+        self.body.rewind if is_retry && self.body.respond_to?(:rewind)
         env = self.to_env(connection)
         logger.debug  { "#{self.class} Sending API request #{env[:method]} #{env[:url].to_s} #{env[:request_headers]}" }
         http_response = connection.app.call(env)
@@ -244,7 +244,7 @@ module Google
           )
         end
 
-        request_env = http_request.to_env(connection)
+        http_request.to_env(connection)
       end
 
       ##

--- a/lib/google/api_client/service/simple_file_store.rb
+++ b/lib/google/api_client/service/simple_file_store.rb
@@ -124,7 +124,7 @@ module Google
         # Read the entire cache file from disk.
         # Will avoid reading if there have been no changes.
         def read_file
-          if !File.exists? @file_path
+          if !File.exist? @file_path
             @cache = nil
           else
             # Check for changes after our last read or write.


### PR DESCRIPTION
This PR addresses several warnings that occur in the library. These warnings occur in projects that use google-api-client. The warnings addressed are:

* assigned but unused variable
* File.exists? is deprecated
* instance variable not initialized
* shadowing outer local variable

You can see these warnings by enabling the `-w` flag when running the specs.

`$ RUBYOPT=-w rake spec`

(There are several more warnings in the specs that are not addressed in this PR, as they will not show up when simply using the library.)