### PR TITLE
Support and test under Rails 3.2, 4.0, 4.1, and 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ rvm:
   - 1.9.3
   - rbx-2
   - jruby
+env:
+  - RAILS_VERSION="~>3.2"
+  - RAILS_VERSION="~>4.0.0"
+  - RAILS_VERSION="~>4.1.0"
+  - RAILS_VERSION="~>4.2.0"
 script: "bundle exec rake spec:all"
 before_install:
  - sudo apt-get update

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
+
+if ENV['RAILS_VERSION']
+  gem 'rails', ENV['RAILS_VERSION']
+end

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'launchy', '~> 2.4'
   s.add_runtime_dependency 'retriable', '~> 1.4'
-  s.add_runtime_dependency 'activesupport', '~> 3.2'
+  s.add_runtime_dependency 'activesupport', '>= 3.2'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'


### PR DESCRIPTION
Presumably the build matrix can be pruned depending on what combinations you feel safe leaving out.