### PR TITLE
Use discovered 'rootUrl' as base URI for services

### DIFF
--- a/lib/google/api_client/discovery/api.rb
+++ b/lib/google/api_client/discovery/api.rb
@@ -30,7 +30,7 @@ module Google
       # Creates a description of a particular version of a service.
       #
       # @param [String] document_base
-      #   Base URI for the service
+      #   Base URI for the discovery document.
       # @param [Hash] discovery_document
       #   The section of the discovery document that applies to this service
       #   version.
@@ -127,6 +127,16 @@ module Google
       end
 
       ##
+      # Returns the root URI for this service.
+      #
+      # @return [Addressable::URI] The root URI.
+      def root_uri
+        return @root_uri ||= (
+          Addressable::URI.parse(self.discovery_document['rootUrl'])
+        )
+      end
+
+      ##
       # Returns true if this API uses a data wrapper.
       #
       # @return [TrueClass, FalseClass]
@@ -148,7 +158,7 @@ module Google
       def method_base
         if @discovery_document['basePath']
           return @method_base ||= (
-            self.document_base.join(Addressable::URI.parse(@discovery_document['basePath']))
+            self.root_uri.join(Addressable::URI.parse(@discovery_document['basePath']))
           ).normalize
         else
           return nil


### PR DESCRIPTION
Fixes #195

A number of Google APIs do not use `www.googleapis.com` as their base URI.  This patch reads the `'rootUrl'` from discovery documents to use as the host name for API requests, fixing request URLs for services such as Pub/Sub API, which hosts its endpoints on `pubsub.googleapis.com`.

Before this patch, the URL of the discovery doc ([`#document_base`](https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/discovery/api.rb#L32)) was used as the root URL for [building service requests](https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/discovery/api.rb#L151).  This exposes the `'rootUrl'` from discovery documents as [`Google::APIClient::API#root_uri`](https://github.com/remi/google-api-ruby-client/blob/1ed677b796afad92b5f232165912ab269c0b4b8a/lib/google/api_client/discovery/api.rb#L133) which is now used as the root URL when [building service requests](https://github.com/remi/google-api-ruby-client/blob/1ed677b796afad92b5f232165912ab269c0b4b8a/lib/google/api_client/discovery/api.rb#L161).

This also fixes an inconsistency where `#document_base` was documented as both ["*Base URI for the service*"](https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/discovery/api.rb#L33) and ["*base URI for the discovery document*"](https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/discovery/api.rb#L139-L142).  Now `#root_uri` is a clear base URI for the service while `#document_base` is the base URI for the discovery document.

**Note**: the `'rootUrl'` property is available on _**all**_ Google API discovery documents.

Also note that I have not (yet) updated [`Google::APIClient::API#batch_path`](https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/discovery/api.rb#L180) to base its URL off of `#root_uri` instead of `#document_base`, simply because I don't currently have a working batch test case and want to be conservative about not breaking existing functionality.  The test suite passes so long as `Google::APIClient::API#batch_path` is not nil.  But `#batch_path` should likely be updated to be rooted off of `#root_uri` now instead of the discovery document `#document_base`.