### PR TITLE
Respect discovered methods with colons in path

### DIFF
--- a/lib/google/api_client/discovery/method.rb
+++ b/lib/google/api_client/discovery/method.rb
@@ -108,7 +108,7 @@ module Google
       # @return [Addressable::Template] The URI template.
       def uri_template
         return @uri_template ||= Addressable::Template.new(
-          self.method_base.join(Addressable::URI.parse(@discovery_document['path']))
+          self.method_base.join(Addressable::URI.parse("./" + @discovery_document['path']))
         )
       end
 

--- a/spec/google/api_client/discovery_spec.rb
+++ b/spec/google/api_client/discovery_spec.rb
@@ -688,5 +688,21 @@ RSpec.describe Google::APIClient do
     it 'should correctly determine the service root_uri' do
       expect(@pubsub.root_uri.to_s).to eq('https://pubsub.googleapis.com/')
     end
+
+    it 'should discover correct method URIs' do
+      list = CLIENT.discovered_method(
+        "pubsub.projects.topics.list", "pubsub", "v1beta2"
+      )
+      expect(list.uri_template.pattern).to eq(
+        "https://pubsub.googleapis.com/v1beta2/{+project}/topics"
+      )
+
+      publish = CLIENT.discovered_method(
+        "pubsub.projects.topics.publish", "pubsub", "v1beta2"
+      )
+      expect(publish.uri_template.pattern).to eq(
+        "https://pubsub.googleapis.com/v1beta2/{+topic}:publish"
+      )
+    end
   end
 end


### PR DESCRIPTION
Update `Google::APIClient::Method#uri_template` to support discovered API methods including colons, eg. Pub/Sub `topics.publish`, `subscriptions.pull`, et al

Fixes #218 