### PR TITLE
Fix discrepency around faraday_option and add it to APIClient::Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Batch requests with the service interface now inherit the service's connection
 * `register_discover_document` now returns the API instance
 * Added `:proxy` option to set Faraday's HTTP proxy setting
-* Added `:faraday_options` option to allow passthrough settings to Faraday connection
+* Added `:faraday_option` option to allow passthrough settings to Faraday connection
 * Drop 1.8.x support
 * This will be the last release with 1.9.x support
 

--- a/lib/google/api_client.rb
+++ b/lib/google/api_client.rb
@@ -82,7 +82,7 @@ module Google
     # @options options[Hash] :force_encoding
     #   Experimental option. True if response body should be force encoded into the charset
     #   specified in the Content-Type header. Mostly intended for compressed content.
-    # @options options[Hash] :faraday_options
+    # @options options[Hash] :faraday_option
     #   Pass through of options to set on the Faraday connection
     def initialize(options={})
       logger.debug { "#{self.class} - Initializing client with options #{options}" }

--- a/lib/google/api_client/service.rb
+++ b/lib/google/api_client/service.rb
@@ -82,6 +82,8 @@ module Google
       #   authenticated, `false` otherwise.
       # @option options [TrueClass, FalseClass] :gzip (default: true)
       #   `true` if gzip enabled, `false` otherwise.
+      # @options options[Hash] :faraday_option
+      #   Pass through of options to set on the Faraday connection
       # @option options [Faraday::Connection] :connection
       #   A custom connection to be used for all requests.
       # @option options [ActiveSupport::Cache::Store, :default] :discovery_cache
@@ -103,7 +105,7 @@ module Google
         params = {}
         [:application_name, :application_version, :authorization, :host, :port,
          :discovery_path, :auto_refresh_token, :key, :user_ip,
-         :ca_file].each do |option|
+         :ca_file, :faraday_option].each do |option|
           if options.include? option
             params[option] = options[option]
           end


### PR DESCRIPTION
There was a small discrepency around Google::ApiClient api It was :
- `:faraday_options` in the inline documentation and in the Changelog
- `:faraday_option` in the actual code and specs

This PR make it uniform and use  `:faraday_option` to be backward compatible.

I also added the option to Google::ApiClient::Service as it was not yet supported there. 