### PR TITLE
Initial set of integration tests against live APIs

### DIFF
--- a/spec/integration_tests/drive_spec.rb
+++ b/spec/integration_tests/drive_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'google/apis/drive_v2'
+require 'googleauth'
+require 'fileutils'
+
+Drive = Google::Apis::DriveV2
+
+RSpec.describe Google::Apis::DriveV2, :if => run_integration_tests? do
+
+  before(:context) do
+    WebMock.allow_net_connect!
+    @drive = Drive::DriveService.new
+    @drive.authorization = Google::Auth.get_application_default([Drive::AUTH_DRIVE])
+  end
+
+  it 'should upload and download files' do
+    # Insert a file
+    content_path = File.join(FIXTURES_DIR, 'files', 'test_api.json')
+    file = @drive.insert_file({title: 'test_file.txt'}, upload_source: content_path)
+    puts "Created file #{file.title} (#{file.id})"
+
+    # Read it back
+    tmp = @drive.get_file(file.id, download_dest: Tempfile.new('drive'))
+
+    # Delete it
+    @drive.delete_file(file.id)
+    puts "File deleted"
+
+    expect(FileUtils.compare_file(content_path, tmp)).to be_truthy
+  end
+
+  after(:context) do
+    WebMock.disable_net_connect!
+  end
+end

--- a/spec/integration_tests/pubsub_spec.rb
+++ b/spec/integration_tests/pubsub_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'google/apis/pubsub_v1beta2'
+require 'googleauth'
+
+Pubsub = Google::Apis::PubsubV1beta2
+
+RSpec.describe Google::Apis::PubsubV1beta2, :if => run_integration_tests? do
+
+  before(:context) do
+    WebMock.allow_net_connect!
+    project = ENV['GOOGLE_PROJECT_ID']
+    @topic_name = "projects/#{project}/topics/test"
+    @subscription_name = "projects/#{project}/subscriptions/test"
+
+    @pubsub = Pubsub::PubsubService.new
+    @pubsub.authorization = Google::Auth.get_application_default([Pubsub::AUTH_PUBSUB])
+    @pubsub.create_topic(@topic_name)
+    @pubsub.create_subscription(@subscription_name, Pubsub::Subscription.new(topic: @topic_name))
+  end
+
+  it 'should publish & receive messages' do
+    # Publish messages
+    request = Pubsub::PublishRequest.new(messages: [])
+    request.messages << Pubsub::Message.new(attributes: { "language" => "en" }, data: 'Hello')
+    request.messages << Pubsub::Message.new(attributes: { "language" => "en" }, data: 'World')
+    @pubsub.publish(@topic_name, request)
+
+    # Pull messages
+    response = @pubsub.pull(@subscription_name, Pubsub::PullRequest.new(max_messages: 5))
+    response.received_messages.each do |received_message|
+      data = received_message.message.data
+      puts "Received #{data}"
+    end
+
+    # Acknowledge receipt
+    ack_ids = response.received_messages.map{ |msg| msg.ack_id }
+    @pubsub.acknowledge(@subscription_name, Pubsub::AcknowledgeRequest.new(ack_ids: ack_ids))
+
+    expect(response.received_messages.length).to eq 2
+  end
+
+  after(:context) do
+    @pubsub.delete_subscription(@subscription_name)
+    @pubsub.delete_topic(@topic_name)
+    WebMock.disable_net_connect!
+  end
+
+end

--- a/spec/integration_tests/url_shortener_spec.rb
+++ b/spec/integration_tests/url_shortener_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'google/apis/urlshortener_v1'
+require 'googleauth'
+
+Urlshortener = Google::Apis::UrlshortenerV1
+
+RSpec.describe Google::Apis::UrlshortenerV1, :if => run_integration_tests? do
+
+  before(:context) do
+    WebMock.allow_net_connect!
+    @shortener = Urlshortener::UrlshortenerService.new
+    @shortener.authorization = Google::Auth.get_application_default([Urlshortener::AUTH_URLSHORTENER])
+  end
+
+  it 'should shorten URLs in a batch' do
+    @urls = []
+    callback = lambda { |url, err| @urls << url unless url.nil? }
+    @shortener.batch do |shortener|
+      shortener.insert_url(Urlshortener::Url.new(long_url: 'https://example.com/foo'), &callback)
+      shortener.insert_url(Urlshortener::Url.new(long_url: 'https://example.com/bar'), &callback)
+      shortener.insert_url(Urlshortener::Url.new(long_url: 'https://example.com/baz'), &callback)
+    end
+    puts @urls.inspect
+    expect(@urls.length).to eq 3
+  end
+
+  after(:context) do
+    WebMock.disable_net_connect!
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,3 +115,8 @@ module Net
     end
   end
 end
+
+def run_integration_tests?
+  ENV['GOOGLE_APPLICATION_CREDENTIALS'] && ENV['GOOGLE_PROJECT_ID']
+end
+


### PR DESCRIPTION
Small set of integration tests to run against live APIs and verify basic functionality in the API (basic requests, upload/download, batching, etc.) Not intended to be a comprehensive suite of tests, but may grow over time.

Requires setting the environment variables GOOGLE_APPLICATION_CREDENTIALS (as in application default credentials) and GOOGLE_PROJECT_ID.
