### PR TITLE
fix drive example + add debug gems for dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :development do
   gem 'coveralls', '~> 0.7.11'
   gem 'rubocop', '~> 0.29'
   gem 'launchy', '~> 2.4'
+  gem 'dotenv'
+  gem 'pry-doc'
 end
 
 platforms :jruby do
@@ -27,6 +29,7 @@ platforms :ruby do
     gem 'yard', '~> 0.8'
     gem 'redcarpet', '~> 3.2'
     gem 'github-markup', '~> 1.3'
+    gem 'pry-byebug'
   end
 end
 

--- a/samples/drive/drive.rb
+++ b/samples/drive/drive.rb
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pass all auth variables to .env file
+# Read more about auth on https://developers.google.com/drive/web/about-auth
+# For example, in my case I added GOOGLE_APPLICATION_CREDENTIALS=credentials.json
+
+require 'dotenv'
+Dotenv.load
+
 require 'tempfile'
 require 'googleauth'
 require 'google/apis/drive_v2'
@@ -22,7 +29,7 @@ drive = Drive::DriveService.new
 drive.authorization = Google::Auth.get_application_default([Drive::AUTH_DRIVE])
 
 # Insert a file
-file = drive.insert_file({title: 'drive.rb'}, upload_source: 'drive.rb')
+file = drive.insert_file({title: 'drive.rb'}, upload_source: __FILE__)
 puts "Created file #{file.title} (#{file.id})"
 
 # Search for it


### PR DESCRIPTION
To ```upload_source``` me must setup full path to file
```ruby
$ bundle exec ruby samples/drive/drive.rb
/usr/local/rvm/gems/ruby-2.0.0-p598/gems/hurley-0.1/lib/hurley/multipart.rb:33:in `initialize': No such file or directory - drive.rb (Errno::ENOENT)
	from /usr/local/rvm/gems/ruby-2.0.0-p598/gems/hurley-0.1/lib/hurley/multipart.rb:33:in `open'
	from /usr/local/rvm/gems/ruby-2.0.0-p598/gems/hurley-0.1/lib/hurley/multipart.rb:33:in `initialize'
```
So fix it + add debug gems to Gemfile