### PR TITLE
fix RequestOptions#merge + test for default options

### DIFF
--- a/lib/google/apis/options.rb
+++ b/lib/google/apis/options.rb
@@ -44,7 +44,7 @@ module Google
 
     # Request options
     class RequestOptions
-      # @!attribute [rw] credentials
+      # @!attribute [rw] authorization
       #   @return [Signet::OAuth2::Client, #apply(Hash)] OAuth2 credentials
       # @!attribute [rw] retries
       #   @return [Fixnum] Number of times to retry requests on server error
@@ -63,7 +63,7 @@ module Google
         return self if options.nil?
 
         new_options = dup
-        %w(authorization retries timeout_sec).each do |opt|
+        members.each do |opt|
           opt = opt.to_sym
           new_options[opt] = options[opt] unless options[opt].nil?
         end

--- a/spec/google/apis/options_spec.rb
+++ b/spec/google/apis/options_spec.rb
@@ -37,4 +37,12 @@ RSpec.describe Google::Apis::RequestOptions do
   it 'should allow nil in merge' do
     expect(options.merge(nil)).to be_an_instance_of(Google::Apis::RequestOptions)
   end
+
+  it 'should override default options' do
+    Google::Apis::RequestOptions.default.header = 'Content-Length: 50'
+    opts = Google::Apis::RequestOptions.new
+    opts.header = 'Content-Length: 70'
+    expect(options.merge(opts).header).to eq 'Content-Length: 70' 
+  end
+
 end


### PR DESCRIPTION
Here
```
 %w(authorization retries timeout_sec).each do |opt|
```
there is no ```header``` option
Also, all this keys we can get with [Struct#members](http://ruby-doc.org/core-2.2.0/Struct.html#method-i-members) method.
Also, add method for overriding default options.