### PR TITLE
Update bundler before travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script: "rake spec:all"
 before_install:
  - sudo apt-get update
  - sudo apt-get install idn
+ - gem update bundler
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Latest builds on travis are broken because of bundler is too old and contains some issues

Refs: bundler/bundler#3558 travis-ci/travis-ci#3531