### PR TITLE
Add Tempfile to if statement of BaseUploadCommand#prepare!

### DIFF
--- a/lib/google/apis/core/upload.rb
+++ b/lib/google/apis/core/upload.rb
@@ -82,7 +82,7 @@ module Google
         # @raise [Google::Apis::ClientError] if upload source is invalid
         def prepare!
           super
-          if upload_source.is_a?(IO) || upload_source.is_a?(StringIO)
+          if upload_source.is_a?(IO) || upload_source.is_a?(StringIO) || upload_source.is_a?(Tempfile)
             self.upload_io = UploadIO.from_io(upload_source, content_type: upload_content_type)
             @close_io_on_finish = false
           elsif upload_source.is_a?(String)

--- a/lib/google/apis/core/upload.rb
+++ b/lib/google/apis/core/upload.rb
@@ -82,7 +82,7 @@ module Google
         # @raise [Google::Apis::ClientError] if upload source is invalid
         def prepare!
           super
-          if upload_source.is_a?(IO) || upload_source.is_a?(StringIO) || upload_source.is_a?(Tempfile)
+          if streamable?(upload_source)
             self.upload_io = UploadIO.from_io(upload_source, content_type: upload_content_type)
             @close_io_on_finish = false
           elsif upload_source.is_a?(String)
@@ -96,6 +96,12 @@ module Google
         # Close IO stream when command done. Only closes the stream if it was opened by the command.
         def release!
           upload_io.close if @close_io_on_finish
+        end
+
+        private
+
+        def streamable?(upload_source)
+          upload_source.is_a?(IO) || upload_source.is_a?(StringIO) || upload_source.is_a?(Tempfile)
         end
       end
 

--- a/spec/google/apis/core/upload_spec.rb
+++ b/spec/google/apis/core/upload_spec.rb
@@ -129,6 +129,20 @@ RSpec.describe Google::Apis::Core::RawUploadCommand do
     end
   end
 
+  context('with Tempfile input') do
+    let(:file) do
+      temp_file = Tempfile.new
+      temp_file.write("Hello world\n")
+      temp_file.rewind
+      temp_file
+    end
+    include_examples 'should upload'
+
+    it 'should not close stream' do
+      expect(file.closed?).to be false
+    end
+  end
+
   context('with file path input') do
     let(:file) { File.join(FIXTURES_DIR, 'files', 'test.txt') }
     include_examples 'should upload'

--- a/spec/google/apis/core/upload_spec.rb
+++ b/spec/google/apis/core/upload_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Google::Apis::Core::RawUploadCommand do
 
   context('with Tempfile input') do
     let(:file) do
-      temp_file = Tempfile.new
+      temp_file = Tempfile.new("tempfile")
       temp_file.write("Hello world\n")
       temp_file.rewind
       temp_file


### PR DESCRIPTION
`Tempfile` is not subclass of `IO`. it is subclass of `Delegator`.
Because of it, `Tempfile` instance is regarded as invalid source.
I think that `Tempfile` is useful to upload to bigquery.
API client should be able to use `Tempfile` object.