### PR TITLE
required 'tempfile'

### DIFF
--- a/lib/google/apis/core/upload.rb
+++ b/lib/google/apis/core/upload.rb
@@ -18,6 +18,7 @@ require 'google/apis/core/api_command'
 require 'google/apis/errors'
 require 'addressable/uri'
 require 'mime-types'
+require "tempfile"
 
 module Google
   module Apis


### PR DESCRIPTION
Otherwise I get:

    gems/google-api-client-0.9/lib/google/apis/core/upload.rb:104:in `streamable?': uninitialized constant Google::Apis::Core::BaseUploadCommand::Tempfile (NameError)

when do

    service.insert_file(metadata, upload_source: "temp.pdf")