### PR TITLE
Cleaner code on regexp

### DIFF
--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -127,7 +127,7 @@ module Google
         #   Updated header value
         def normalize_fields_param(fields)
           # TODO: Generate map of parameter names during code gen. Small possibility that camelization fails
-          fields.gsub(/:/, '').gsub(/[\w_]+/) { |str| ActiveSupport::Inflector.camelize(str, false) }
+          fields.gsub(/:/, '').gsub(/\w+/) { |str| ActiveSupport::Inflector.camelize(str, false) }
         end
       end
     end


### PR DESCRIPTION
`/[\w_]+/` is equivalent to `/\w+/`. 
 > /\w/ - A word character ([a-zA-Z0-9_])

Ruby-doc [reference](http://ruby-doc.org/core-2.3.0/Regexp.html#class-Regexp-label-Character+Classes).

This will fix the warning when running `ruby -vr google/apis/drive_v3 -e ''`: 
```
/path/to/gems/google-api-client-0.9.1/lib/google/apis/core/api_command.rb:130: warning: character class has duplicated range: /[\w_]+/
```