### PR TITLE
Update 'samples' link to 'samples' folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Samples for versions 0.9 and onward can be found in the `samples` directory.
 Contributions for additional samples are welcome. See [CONTRIBUTING](CONTRIBUTING.md).
 
 Samples for previous versions can be found in the
-[google-api-ruby-client-samples](https://github.com/google/google-api-ruby-client-samples)
-repository.
+[samples](samples)
+folder.
 
 
 ## Generating APIs


### PR DESCRIPTION
The original samples link pointed to the (now) out of date examples for version 0.8 of this gem. I lost a few hours wondering why things were not working.

Hoping to save someone else the time I lost (and reap the karmic bounty thereof).