### PR TITLE
Assign `open_timeout` option in `apply_request_options`

### DIFF
--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -292,6 +292,7 @@ module Google
           end
           req.header.update(header)
           req.options.timeout = options.timeout_sec
+          req.options.open_timeout = options.open_timeout_sec
         end
 
         private


### PR DESCRIPTION
In current version, developer cannot change connection timeout of httpclient per API request.
google-api-ruby-client always uses default value (20 sec).

For example

```ruby
Bigquery.client.insert_job(
  Bigquery::PROJECT_ID,
  {
    configuration: {
      load: {
        destination_table: {
          project_id: Bigquery::PROJECT_ID,
          dataset_id: Bigquery::DATA_SET,
          table_id: "test",
        },
        schema: {
          fields: [
            {
              name: "id",
              type: "STRING",
              mode: "REQUIRED"
            },
            {
              name: "timestamp",
              type: "TIMESTAMP",
              mode: "NULLABLE"
            },
          ]
        },
      }
    }
  },
  {upload_source: File.open("./upload_source.log"), content_type: "application/octet-stream", options: {timeout_sec: 300, open_timeout_sec: 300}},
```
I set RequestOptions, but httpclient uses default `open_timeout_sec`.
this is very troubled when I upload a large file to Bigquery.
Even if `timeout_sec` is set, connection timeout is always overrided by `open_timeout_sec`

this patch fixes it.
