### PR TITLE
Fix Hash value assignment in JsonSupport#getter_fn

### DIFF
--- a/lib/google/apis/core/json_representation.rb
+++ b/lib/google/apis/core/json_representation.rb
@@ -39,7 +39,7 @@ module Google
             ivar_name = "@#{name}".to_sym
             lambda do |_|
               if respond_to?(:[])
-                self[name] || instance_variable_get(ivar_name)
+                self.key?(name) ? self[name] : instance_variable_get(ivar_name)
               else
                 instance_variable_get(ivar_name)
               end

--- a/lib/google/apis/core/json_representation.rb
+++ b/lib/google/apis/core/json_representation.rb
@@ -38,8 +38,8 @@ module Google
           def getter_fn(name)
             ivar_name = "@#{name}".to_sym
             lambda do |_|
-              if respond_to?(:[])
-                self.key?(name) ? self[name] : instance_variable_get(ivar_name)
+              if respond_to?(:fetch)
+                fetch(name, instance_variable_get(ivar_name))
               else
                 instance_variable_get(ivar_name)
               end

--- a/spec/google/apis/core/json_representation_spec.rb
+++ b/spec/google/apis/core/json_representation_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
       attr_accessor :nil_value
       attr_accessor :numeric_value
       attr_accessor :string_value
-      attr_accessor :boolean_value
+      attr_accessor :boolean_value_true
+      attr_accessor :boolean_value_false
       attr_accessor :date_value
       attr_accessor :bytes_value
       attr_accessor :items
@@ -44,7 +45,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
       property :nil_value, as: 'nilValue'
       property :numeric_value, as: 'numericValue'
       property :string_value, as: 'stringValue'
-      property :boolean_value, as: 'booleanValue'
+      property :boolean_value_true, as: 'booleanValueTrue'
+      property :boolean_value_false, as: 'booleanValueFalse'
       property :date_value, as: 'dateValue', type: DateTime
       property :bytes_value, as: 'bytesValue', base64: true
       property :items
@@ -75,7 +77,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
     end
 
     it 'serializes boolean values' do
-      expect(json).to be_json_eql(%(true)).at_path('booleanValue')
+      expect(json).to be_json_eql(%(true)).at_path('booleanValueTrue')
+      expect(json).to be_json_eql(%(false)).at_path('booleanValueFalse')
     end
 
     it 'serializes date values' do
@@ -107,7 +110,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
       model.numeric_value = 123
       model.string_value = 'test'
       model.date_value = DateTime.new(2015, 5, 1, 12)
-      model.boolean_value = true
+      model.boolean_value_true = true
+      model.boolean_value_false = false
       model.bytes_value = 'Hello world'
       model.items = [1, 2, 3]
       model.child = child_class.new
@@ -127,7 +131,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
         string_value: 'test',
         numeric_value: 123,
         date_value: DateTime.new(2015, 5, 1, 12),
-        boolean_value: true,
+        boolean_value_true: true,
+        boolean_value_false: false,
         bytes_value: 'Hello world',
         items: [1, 2, 3],
         child: {
@@ -146,7 +151,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
       json = <<EOF
 { "stringValue": "test",
   "nilValue": null,
-  "booleanValue": true,
+  "booleanValueTrue": true,
+  "booleanValueFalse": false,
   "numericValue": 123,
   "dateValue": "2015-05-01T12:00:00+00:00",
   "bytesValue": "SGVsbG8gd29ybGQ=",
@@ -170,7 +176,8 @@ EOF
     end
 
     it 'deserializes boolean values' do
-      expect(model.boolean_value).to be_truthy
+      expect(model.boolean_value_true).to be_truthy
+      expect(model.boolean_value_false).to be_falsey
     end
 
     it 'deserializes date values' do


### PR DESCRIPTION
current version sends `false` value as `nil` if given request parameter is Hash.
because of it, developler cannot change several options that are boolean type and default `true`.

For example `flatten_results` of Bigquery API,
```ruby
Bigquery.client.insert_job(
  Bigquery::PROJECT_ID,
  {
    configuration: {
      query: {
        flatten_results: false,
        query: "SELECT 1",
      }
    }
  }
)
```

I expects

```json
{"configuration": {"query": {"flattenResults": false, "query": "SELECT 1"}}}
```

But actual request parameter is

```json
{"configuration": {"query": {"flattenResults": null, "query": "SELECT 1"}}}
```
