### PR TITLE
replace multi_json dependency with regular stdlib JSON

### DIFF
--- a/bin/generate-api
+++ b/bin/generate-api
@@ -6,7 +6,6 @@ require 'thor'
 require 'open-uri'
 require 'google/apis/discovery_v1'
 require 'google/apis/generator'
-require 'multi_json'
 require 'logger'
 
 module Google

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib', 'generated', 'third_party']
 
   spec.add_runtime_dependency 'representable', '~> 2.3.0'
-  spec.add_runtime_dependency 'multi_json', '~> 1.11'
   spec.add_runtime_dependency 'retriable', '~> 2.0'
   spec.add_runtime_dependency 'activesupport', '>= 3.2'
   spec.add_runtime_dependency 'addressable', '~> 2.3'

--- a/lib/google/api_client/client_secrets.rb
+++ b/lib/google/api_client/client_secrets.rb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-require 'compat/multi_json'
+require 'json'
 
 
 module Google
@@ -71,7 +70,7 @@ module Google
             search_path = File.expand_path(File.join(search_path, '..'))
           end
         end
-        data = File.open(filename, 'r') { |file| MultiJson.load(file.read) }
+        data = File.open(filename, 'r') { |file| JSON.load(file.read) }
         return self.new(data)
       end
 
@@ -119,7 +118,7 @@ module Google
       # @return [String]
       #   JSON
       def to_json
-        return MultiJson.dump(to_hash)
+        return Json.dump(to_hash)
       end
 
       def to_hash

--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -17,7 +17,7 @@ require 'addressable/uri'
 require 'addressable/template'
 require 'google/apis/core/http_command'
 require 'google/apis/errors'
-require 'multi_json'
+require 'json'
 require 'retriable'
 
 module Google
@@ -113,7 +113,7 @@ module Google
         #  HTTP response body
         # @return [Hash]
         def parse_error(body)
-          hash = MultiJson.load(body)
+          hash = JSON.load(body)
           hash['error']['errors'].first
         rescue
           nil

--- a/lib/google/apis/generator/annotator.rb
+++ b/lib/google/apis/generator/annotator.rb
@@ -15,7 +15,7 @@
 require 'logger'
 require 'erb'
 require 'yaml'
-require 'multi_json'
+require 'json'
 require 'active_support/inflector'
 require 'google/apis/core/logging'
 require 'google/apis/generator/template'

--- a/spec/google/api_client/client_secrets_spec.rb
+++ b/spec/google/api_client/client_secrets_spec.rb
@@ -23,7 +23,7 @@ FIXTURES_PATH = File.expand_path('../../../fixtures', __FILE__)
 RSpec.describe Google::APIClient::ClientSecrets do
   describe '::new' do
     let(:filename) { File.join(FIXTURES_PATH, 'files', 'client_secrets.json') }
-    let(:data) { File.open(filename, 'r') { |file| MultiJson.load(file.read) } }
+    let(:data) { File.open(filename, 'r') { |file| JSON.load(file.read) } }
 
     context 'without options' do
       subject { Google::APIClient::ClientSecrets.new(data) }
@@ -367,7 +367,7 @@ RSpec.describe Google::APIClient::ClientSecrets do
   context 'with invalid JSON file' do
     it 'should raise exception' do
       file = File.join(FIXTURES_PATH, 'files', 'invalid.json')
-      expect { Google::APIClient::ClientSecrets.load(file) }.to raise_exception(MultiJson::ParseError)
+      expect { Google::APIClient::ClientSecrets.load(file) }.to raise_exception(JSON::ParserError)
     end
   end
 


### PR DESCRIPTION
JSON has been part of the ruby stdlib since 1.9.0 (see https://github.com/ruby/ruby/commit/af1c4167), and the latest version of this gem requires ruby 2.0 or better.

Would you consider removing multi_json as a dependency, and just using `require 'json'` instead? Rails recently made a similar change (https://github.com/rails/rails/pull/23453), which has prompted other libraries to consider the same issue (like [simplecov](https://github.com/colszowka/simplecov/issues/458) and [stripe](https://github.com/stripe/stripe-ruby/pull/379)).

See also this recent [blog post](http://www.mikeperham.com/2016/02/09/kill-your-dependencies/).
