### PR TITLE
Add an authorization technique to the docs using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ result = translate.list_translations('Hello world!', 'es', source: 'en')
 puts result.translations.first.translated_text
 ```
 
+### Authorization using environment variables
+
+The [GoogleAuth Library for Ruby](https://github.com/google/google-auth-library-ruby) also supports authorization via
+environment variables if you do not want to check in developer credentials
+or private keys. Simply set the following variables for your application:
+
+```sh
+GOOGLE_ACCOUNT_TYPE="YOUR ACCOUNT TYPE" # ie. 'service'
+GOOGLE_CLIENT_EMAIL="YOUR GOOGLE DEVELOPER EMAIL"
+GOOGLE_PRIVATE_KEY="YOUR GOOGLE DEVELOPER API KEY"
+```
+
 ## Samples
 
 Samples for versions 0.9 and onward can be found in the `samples` directory.


### PR DESCRIPTION
[Google Auth](https://github.com/google/google-auth-library-ruby) supports environment variables as a means of authorizing service apps. Add this technique to the docs for the benefit of others. Issue [#370](https://github.com/google/google-api-ruby-client/issues/370)