### PR TITLE
Remove comments specifying encoding

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'google/apis/version'

--- a/spec/google/api_client/client_secrets_spec.rb
+++ b/spec/google/api_client/client_secrets_spec.rb
@@ -1,5 +1,3 @@
-# encoding:utf-8
-
 # Copyright 2013 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In ruby 2.0, the default encoding is UTF-8, so these magic comment
directives can be safely removed.

https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/