### PR TITLE
Package fewer files in the gem

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -12,9 +12,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/google/google-api-ruby-client'
   spec.license       = 'Apache 2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`
+                       .split("\x0")
+                       .reject { |f| f.match(%r{^(spec|script)/|^api_names_out}) }
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib', 'generated', 'third_party']
 
   spec.required_ruby_version = '~> 2.0'


### PR DESCRIPTION
* Do not distribute test files
* Do not distribute the intermediate api_names_out.yaml file

> Reduces the packaged gem size from 1.8Mb to 1.6Mb

The practice of not distributing test files with a gem was originally
discussed and adopted by the Bundler team here:
https://github.com/bundler/bundler/pull/3207