### PR TITLE
Google::APICilent::ClientSecrets Allow symbols for credential `flow`

### DIFF
--- a/lib/google/api_client/client_secrets.rb
+++ b/lib/google/api_client/client_secrets.rb
@@ -82,7 +82,7 @@ module Google
       def initialize(options={})
         # Client auth configuration
         @flow = options[:flow] || options.keys.first.to_s || 'web'
-        fdata = options[@flow]
+        fdata = options[@flow.to_sym] || options[@flow]
         @client_id = fdata[:client_id] || fdata["client_id"]
         @client_secret = fdata[:client_secret] || fdata["client_secret"]
         @redirect_uris = fdata[:redirect_uris] || fdata["redirect_uris"]

--- a/spec/google/api_client/client_secrets_spec.rb
+++ b/spec/google/api_client/client_secrets_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Google::APIClient::ClientSecrets do
 
       context 'option keys are symbol' do
         let(:symbol_options) do
-          { 'samples' =>
+          { samples:
             {
               access_token:         'sample_access_token',
               auth_uri:             'sample_auth_uri',


### PR DESCRIPTION
Because of my production environment, adding a JSON file a little bit of a pain. However: using the `ClientSecrets` initialiser I set my credentials manually from my environment variables. I noticed that while all the credential details can be either a String or a Symbol, the 'flow' (i.e., `web`) **must** be a string.

This allows  to accept both a string and a symbol, which feels a little better to me because of the consistency.