### PR TITLE
upgrade representable

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_runtime_dependency 'representable', '~> 2.3.0'
+  spec.add_runtime_dependency 'representable', '~> 3.0'
   spec.add_runtime_dependency 'retriable', '~> 2.0'
   spec.add_runtime_dependency 'addressable', '~> 2.3'
   spec.add_runtime_dependency 'mime-types', '>= 1.6'

--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -51,7 +51,7 @@ module Google
           query[FIELDS_PARAM] = normalize_fields_param(query[FIELDS_PARAM]) if query.key?(FIELDS_PARAM)
           if request_representation && request_object
             header[:content_type] ||= JSON_CONTENT_TYPE
-            self.body = request_representation.new(request_object).to_json(skip_undefined: true)
+            self.body = request_representation.new(request_object).to_json(user_options: { skip_undefined: true })
           end
           super
         end

--- a/lib/google/apis/core/json_representation.rb
+++ b/lib/google/apis/core/json_representation.rb
@@ -55,7 +55,7 @@ module Google
           def if_fn(name)
             ivar_name = "@#{name}".to_sym
             lambda do |opts|
-              if opts[:skip_undefined]
+              if opts[:user_options] && opts[:user_options][:skip_undefined]
                 if respond_to?(:key?)
                   self.key?(name) || instance_variable_defined?(ivar_name)
                 else
@@ -137,7 +137,7 @@ module Google
 
         def to_json
           representation = self.class.const_get(:Representation)
-          representation.new(self).to_json(skip_undefined: true)
+          representation.new(self).to_json(user_options: { skip_undefined: true })
         end
       end
     end

--- a/spec/google/apis/core/json_representation_spec.rb
+++ b/spec/google/apis/core/json_representation_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
   end
 
   context 'with model object' do
-    let(:json) { representer_class.new(model).to_json(skip_undefined: true) }
+    let(:json) { representer_class.new(model).to_json(user_options: { skip_undefined: true }) }
     let(:model) do
       model = model_class.new
       model.nil_value = nil
@@ -132,7 +132,7 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
   end
 
   context 'with hash' do
-    let(:json) { representer_class.new(model).to_json(skip_undefined: true) }
+    let(:json) { representer_class.new(model).to_json(user_options: { skip_undefined: true }) }
     let(:model) do
       {
         nil_value: nil,


### PR DESCRIPTION
Just started using this gem so I don't admit to being an expert, but I am somewhat familiar with representable and this seems like what we are shooting for and now tests pass.   The change is from passing options straight into to_json or to_hash to passing the key :user_options.