### PR TITLE
Use twiddle-wakka for dependency example in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ migrate to the latest version.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'google-api-client', '0.9'
+gem 'google-api-client', '~> 0.9'
 
 ```
 


### PR DESCRIPTION
This just bit me because of an ```uninitialized constant Google::Apis::Core::JsonObjectSupport``` error with generated API files, so I thought I would fix this up for someone in the future.

For dependency resolution, this specifies any version of 'google-api-client' 0.9 is valid, but 1.0 is not.