### PR TITLE
allow older thor versions at runtime

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mime-types', '>= 1.6'
   spec.add_runtime_dependency 'hurley', '~> 0.1'
   spec.add_runtime_dependency 'googleauth', '~> 0.5'
-  spec.add_runtime_dependency 'thor', '~> 0.19'
+  spec.add_runtime_dependency 'thor', '~> 0.14'
   spec.add_runtime_dependency 'httpclient', '~> 2.7'
   spec.add_runtime_dependency 'memoist', '~> 0.11'
 end


### PR DESCRIPTION
Hello!
I'm using this gem on a old Rails application where i'm stuck with a thor ` ~> 0.14.1` dependency.
This gem requires `~> 0.19` (from gemspec and also a couple of minor development dependencies) but it also work well with thor 0.14 (specs passes).

So, can we lower the thor dependency?
This will not change anything for almost anyone (pointing at latest 0.x version) but will allow some unlucky old apps to use this gem.

Thanks :)
