### PR TITLE
remove thor as runtime dependency

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mime-types', '>= 1.6'
   spec.add_runtime_dependency 'hurley', '~> 0.1'
   spec.add_runtime_dependency 'googleauth', '~> 0.5'
-  spec.add_runtime_dependency 'thor', '~> 0.19'
   spec.add_runtime_dependency 'httpclient', '~> 2.7'
   spec.add_runtime_dependency 'memoist', '~> 0.11'
+
+  spec.add_development_dependency 'thor', '~> 0.19'
 end


### PR DESCRIPTION
thor is used only to generate the api folder.