### PR TITLE
Fixes broken filters URL reference

### DIFF
--- a/generated/google/apis/analyticsreporting_v4/classes.rb
+++ b/generated/google/apis/analyticsreporting_v4/classes.rb
@@ -469,8 +469,7 @@ module Google
         # following expression selects `ga:browser` dimension which starts with
         # Firefox; `ga:browser=~^Firefox`. For more information on dimensions
         # and metric filters, see
-        # [Filters reference](https://developers.google.com/analytics/devguides/
-        # reporting/core/v3/reference#filters).
+        # [Filters reference](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#filters).
         # Corresponds to the JSON property `filtersExpression`
         # @return [String]
         attr_accessor :filters_expression


### PR DESCRIPTION
Because of the line wrap in the Rubydoc, the URL for filters documentation ends up with an extra %20A in it, which breaks the link from Rubydoc. This undoes the line break so the documentation link is correct. I left it pointing to the V3 docs, since the V4 docs don't seem to have a reference section yet.
