### PR TITLE
Fix typo of api names yaml

### DIFF
--- a/api_names.yaml
+++ b/api_names.yaml
@@ -343,7 +343,7 @@
 "/calendar:v3/EventReminder/method": reminder_method
 "/calendar:v3/calendar.events.instances": list_event_instances
 "/calendar:v3/calendar.events.quickAdd": quick_add_event
-/civicinfo:v2/DivisionSearchResponse": search_division_response
+"/civicinfo:v2/DivisionSearchResponse": search_division_response
 "/civicinfo:v2/ElectionsQueryResponse": query_elections_response
 "/civicinfo:v2/civicinfo.divisions.search": search_divisions
 "/civicinfo:v2/civicinfo.elections.electionQuery": query_election


### PR DESCRIPTION
It seems the beginning of quotation was forgotten at line 346 of api_names.yml. Sorry for the small pull request.