### PR TITLE
Allow retriable 3.0

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.0'
 
   spec.add_runtime_dependency 'representable', '~> 2.3.0'
-  spec.add_runtime_dependency 'retriable', '~> 2.0'
+  spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.3'
   spec.add_runtime_dependency 'mime-types', '>= 1.6'
   spec.add_runtime_dependency 'hurley', '~> 0.1'


### PR DESCRIPTION
`Retriable` 3.0 involves changes to gem configuration that this gem doesn't make use of.