### PR TITLE
Remove unsupported build matrix entry in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,23 @@ language: ruby
 rvm:
   - 2.3.0
   - 2.2
-  - 2.0.0
   - 2.1
+  - 2.0.0
   - jruby-9000
 env:
   - RAILS_VERSION="~>3.2"
   - RAILS_VERSION="~>4.0.0"
   - RAILS_VERSION="~>4.1.0"
   - RAILS_VERSION="~>4.2.0"
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      env: RAILS_VERSION="~>4.2.0"
 script: "bundle exec rake spec:all"
 before_install:
- - sudo apt-get update
- - sudo apt-get install idn
- - gem update bundler
+  - sudo apt-get update
+  - sudo apt-get install idn
+  - gem update bundler
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Rails 4.2.0 no longer supports Ruby 2.0.0, so this commit excludes it
from Travis builds.