### PR TITLE
Update Migrating guide

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -61,6 +61,8 @@ are expected to be added by end of Q2 2015.
 The underlying [Signet](https://github.com/google/signet) is still used for authorization. OAuth 2 credentials obtained
 previously will continue to work with the `0.9` version. OAuth 1 is no longer supported.
 
+If your where using a PKCS12 file to authorize, we recommend you to use a client_secret.json file with googleauth.
+
 ## Media uploads
 
 Media uploads are significantly simpler in `0.9`.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -61,7 +61,7 @@ are expected to be added by end of Q2 2015.
 The underlying [Signet](https://github.com/google/signet) is still used for authorization. OAuth 2 credentials obtained
 previously will continue to work with the `0.9` version. OAuth 1 is no longer supported.
 
-If your where using a PKCS12 file to authorize, we recommend you to use a client_secret.json file with googleauth.
+If you were using a PKCS12 file to authorize, we recommend you generate a new key for the service account using the JSON format ( client_secret.json) file with googleauth.
 
 ## Media uploads
 


### PR DESCRIPTION
Migrating from 0.8 to 0.9 has been an extremely painful process, I will also add a full sample for using Google::Auth::ServiceAccountCredentials