### PR TITLE
add attriubte to the metadata of youtube uploader sample

### DIFF
--- a/samples/cli/lib/samples/you_tube.rb
+++ b/samples/cli/lib/samples/you_tube.rb
@@ -35,9 +35,12 @@ module Samples
       metadata  = {
         snippet: {
           title: options[:title] || file
+        },
+        status: {
+          privacy_status: 'unlisted'
         }
       }
-      result = youtube.insert_video('snippet', metadata, upload_source: file)
+      result = youtube.insert_video('snippet,status', metadata, upload_source: file)
       say "Upload complete"
     end
   end


### PR DESCRIPTION
In the sample code of v0.7, the keys of metadata was written in camel-case, but I have to write in snake-case in current version of the SDK. I have added an attribute to the sample code to guide users to use snake-case.
https://developers.google.com/youtube/v3/code_samples/ruby?hl=ja#upload_a_video

- the sample code for the current version is posted here.
https://github.com/google/google-api-ruby-client/issues/302#issuecomment-152264147