### PR TITLE
Update generator to use batchPath instead of hardcoded path

### DIFF
--- a/lib/google/apis/generator/templates/service.rb.tmpl
+++ b/lib/google/apis/generator/templates/service.rb.tmpl
@@ -42,6 +42,7 @@ module Google
 <% end -%>
         def initialize
           super('<%= api.root_url %>', '<%= api.service_path %>')
+          @batch_path = '<%= api.batch_path %>'
         end
 <% for api_method in api.all_methods -%>
 <%= indent(include('method', :api_method => api_method, :api => api), 8) -%>

--- a/spec/fixtures/files/test_api.json
+++ b/spec/fixtures/files/test_api.json
@@ -7,6 +7,7 @@
   "basePath": "/test/",
   "rootUrl": "https://www.googleapis.com/",
   "servicePath": "test/v1/",
+  "batchPath": "batch/test/v1",
   "rpcPath": "/rpc",
   "auth": {
     "oauth2": {

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -186,6 +186,20 @@ EOF
         end
       end.to raise_error(Google::Apis::ClientError)
     end
+
+    it 'should prevent mixing services in batch' do
+      expect do |b|
+        service.batch do |service|
+          command = service.send(:make_simple_command, :get, 'zoo/animals', {})
+          service.send(:execute_or_queue_command, command, &b)
+
+          service2 = service.dup
+          command2 = service.send(:make_simple_command, :get, 'zoo/animals', {})
+          service2.send(:execute_or_queue_command, command2, &b)
+        end
+      end.to raise_error
+
+    end
   end
 
   context 'with batch uploads' do

--- a/spec/google/apis/generator/generator_spec.rb
+++ b/spec/google/apis/generator/generator_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Google::Apis::Generator do
       puts generator.dump_api_names
       tempdir = Dir.mktmpdir
       generated_files.each do |key, content|
+        puts content
         path = File.join(tempdir, key)
         FileUtils.mkdir_p(File.dirname(path))
         File.open(path, 'w') do |f|
@@ -45,6 +46,10 @@ RSpec.describe Google::Apis::Generator do
     context 'with the generated service' do
       it 'should set the base URL' do
         expect(service.root_url.to_s).to eql('https://www.googleapis.com/')
+      end
+
+      it 'should set the batch path' do
+        expect(service.batch_path).to eql('batch/test/v1')
       end
 
       it 'should define global methods from discovery' do


### PR DESCRIPTION
Fixes #523, though APIs will need to be regenerated after this.

Googlers: See b/32514652 for reference.