### PR TITLE
Use addressable 2.5.1 for escaping URI correctly

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'representable', '~> 3.0'
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
-  spec.add_runtime_dependency 'addressable', '~> 2.3'
+  spec.add_runtime_dependency 'addressable', '~> 2.5'
   spec.add_runtime_dependency 'mime-types', '>= 1.6'
   spec.add_runtime_dependency 'hurley', '~> 0.1'
   spec.add_runtime_dependency 'googleauth', '~> 0.5'

--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -143,7 +143,7 @@ module Google
         # @return [void]
         def prepare!
           header.update(options.header) if options && options.header
-          self.url = url.expand(params) if url.is_a?(Addressable::Template)
+          self.url = url.expand(params, nil, false) if url.is_a?(Addressable::Template)
           url.query_values = query.merge(url.query_values || {})
 
           if allow_form_encoding?

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -110,6 +110,21 @@ RSpec.describe Google::Apis::Core::BaseService do
     include_examples 'with options'
   end
 
+  context 'when making simple commands with parameters' do
+    let(:command) { service.send(:make_simple_command, :get, 'zoo/{animals}', authorization: 'foo') }
+
+    it 'should return the correct command type' do
+      expect(command).to be_an_instance_of(Google::Apis::Core::ApiCommand)
+    end
+
+    it 'should build a correct URL' do # see. https://github.com/google/google-api-ruby-client/issues/557
+      url = command.url.expand({animals: '（multi byte）'}, nil, false).to_s
+      expect(url).to eql 'https://www.googleapis.com/zoo/%EF%BC%88multi%20byte%EF%BC%89'
+    end
+
+    include_examples 'with options'
+  end
+
   context 'when making download commands' do
     let(:command) { service.send(:make_download_command, :get, 'zoo/animals', authorization: 'foo') }
 


### PR DESCRIPTION
fix https://github.com/google/google-api-ruby-client/issues/557

Now, addressable 2.5.1 is released(https://github.com/sporkmonger/addressable/releases/tag/addressable-2.5.1). This release includes fixing https://github.com/sporkmonger/addressable/issues/258 . So this gem follow this.

Could you review this?