### PR TITLE
Add Hash support to fetch_all

### DIFF
--- a/lib/google/apis/core/base_service.rb
+++ b/lib/google/apis/core/base_service.rb
@@ -69,6 +69,13 @@ module Google
                 break if @max && item_count > @max
                 yield item
               end
+            elsif items.kind_of?(Hash)
+              items.each do |key, val|
+                item_count = item_count + 1
+                break if @max && item_count > @max
+                item = { key => val }
+                yield item
+              end
             elsif items
               # yield singular non-nil items (for genomics API)
               yield items

--- a/lib/google/apis/core/base_service.rb
+++ b/lib/google/apis/core/base_service.rb
@@ -73,8 +73,7 @@ module Google
               items.each do |key, val|
                 item_count = item_count + 1
                 break if @max && item_count > @max
-                item = { key => val }
-                yield item
+                yield key, val
               end
             elsif items
               # yield singular non-nil items (for genomics API)

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -351,7 +351,7 @@ EOF
       end
 
       it 'should collate hash entries' do
-        expect(service.fetch_all(items: :hash_) { |token| responses[token] } ).to contain_exactly({ 'foo' => 1 }, { 'bar' => 2 }, { 'baz' => 3 })
+        expect(service.fetch_all(items: :hash_) { |token| responses[token] } ).to contain_exactly(['foo', 1], ['bar', 2], ['baz', 3])
       end
 
       it 'should allow limiting the number of items to fetch' do

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -313,11 +313,11 @@ EOF
       let(:responses) do
         data = {}
         data[nil] = OpenStruct.new(
-          next_page_token: 'p1', alt_page_token: 'p2', items: ['a', 'b', 'c'], alt_items: [1, 2, 3], singular: 'foo')
+          next_page_token: 'p1', alt_page_token: 'p2', items: ['a', 'b', 'c'], alt_items: [1, 2, 3], singular: 'foo', hash_: { 'foo' => 1, 'bar' => 2 })
         data['p1'] = OpenStruct.new(
-          next_page_token: 'p2', items: ['d', 'e', 'f'], alt_items: [4, 5, 6], singular: 'bar')
+          next_page_token: 'p2', items: ['d', 'e', 'f'], alt_items: [4, 5, 6], singular: 'bar', hash_: nil)
         data['p2'] = OpenStruct.new(
-          next_page_token: nil, alt_page_token: nil, items: ['g', 'h', 'i'], alt_items: [7, 8, 9], singular: 'baz')
+          next_page_token: nil, alt_page_token: nil, items: ['g', 'h', 'i'], alt_items: [7, 8, 9], singular: 'baz', hash_: { 'baz' => 3 })
         data
       end
 
@@ -348,6 +348,10 @@ EOF
 
       it 'should allow iterating over singular items' do
         expect(service.fetch_all(items: :singular) { |token| responses[token] } ).to contain_exactly('foo', 'bar', 'baz')
+      end
+
+      it 'should collate hash entries' do
+        expect(service.fetch_all(items: :hash_) { |token| responses[token] } ).to contain_exactly({ 'foo' => 1 }, { 'bar' => 2 }, { 'baz' => 3 })
       end
 
       it 'should allow limiting the number of items to fetch' do


### PR DESCRIPTION
This commit aligns the behavior of `fetch_all` over map responses with
that of arrays (returning a single collection with all entries).

Fixes https://github.com/google/google-api-ruby-client/issues/584