### PR TITLE
Use String#bytesize to calculate download offset

### DIFF
--- a/lib/google/apis/core/download.rb
+++ b/lib/google/apis/core/download.rb
@@ -89,7 +89,7 @@ module Google
               end
               # logger.debug { sprintf('Writing chunk (%d bytes, %d total)', chunk.length, bytes_read) }
               @download_io.write(chunk)
-              @offset += chunk.length
+              @offset += chunk.bytesize
             end
           end
 


### PR DESCRIPTION
`String#length` returns the number of characters in the string in the encoding the string is in, which can be different depending on the encoding.

For example, a string containing one emoji will be one 1 length in UTF-8 encoding, and 4 in length in binary encoding, because that character ultimately consists of 4 bytes.

When we're using IO objects like Files or TCP sockets, they are reading content in bytes (not in length) and the "Range" header is specified in bytes. That means we also want to calculate the offset in bytes, so we use `String#bytesize`, which will work correctly regardless of whether the HTTP client returns chunks in binary or UTF-8 encoding.