### PR TITLE
Allow automatic method name clash resolution

### DIFF
--- a/lib/google/apis/generator.rb
+++ b/lib/google/apis/generator.rb
@@ -27,8 +27,9 @@ module Google
       Discovery = Google::Apis::DiscoveryV1
 
       # Load templates
-      def initialize(api_names: nil)
-        @names = Google::Apis::Generator::Names.new(api_names || File.join(Google::Apis::ROOT, 'api_names.yaml'))
+      def initialize(api_names: nil, api_names_out: nil)
+        @names = Google::Apis::Generator::Names.new(api_names_out || File.join(Google::Apis::ROOT, 'api_names_out.yaml'),
+                                                    api_names || File.join(Google::Apis::ROOT, 'api_names.yaml'))
         @module_template = Template.load('module.rb')
         @service_template = Template.load('service.rb')
         @classes_template = Template.load('classes.rb')

--- a/lib/google/apis/generator/annotator.rb
+++ b/lib/google/apis/generator/annotator.rb
@@ -78,6 +78,10 @@ module Google
           preferred_name
         end
 
+        def [](key)
+          @names[key]
+        end
+
         def []=(key, value)
           @names[key] = value
         end
@@ -182,7 +186,13 @@ module Google
 
         def collect_method_names_for_rpc(resource, method_names_for_rpc)
           resource.api_methods.each do |_k, v|
-            method_name_for_rpc = @names.infer_method_name_for_rpc(v, false)
+            # First look for the method name in the `@names` hash. If there's
+            # no override set, generate it without inserting the generated name
+            # into the `@names` hash.
+            method_name_for_rpc = @names[@names.key]
+            if method_name_for_rpc.nil?
+              method_name_for_rpc = @names.infer_method_name_for_rpc(v, false)
+            end
             method_names_for_rpc << method_name_for_rpc if method_name_for_rpc
           end unless resource.api_methods.nil?
 

--- a/lib/google/apis/generator/annotator.rb
+++ b/lib/google/apis/generator/annotator.rb
@@ -41,12 +41,16 @@ module Google
         include Google::Apis::Core::Logging
         include NameHelpers
 
-        def initialize(file_path = nil)
-          if file_path
-            logger.info { sprintf('Loading API names from %s', file_path) }
-            @names = YAML.load(File.read(file_path)) || {}
+        def initialize(names_out_file_path = nil, names_file_path = nil)
+          if names_out_file_path
+            logger.info { sprintf('Loading API names from %s', names_out_file_path) }
+            @names = YAML.load(File.read(names_out_file_path)) || {}
           else
             @names = {}
+          end
+          if names_file_path
+            logger.info { sprintf('Loading API names from %s', names_file_path) }
+            @names = @names.merge(YAML.load(File.read(names_file_path)) || {})
           end
           @path = []
         end


### PR DESCRIPTION
If the method name is generated from the request type, there is a
possibility of a clash if two methods take the same request type. For
example, if two unique methods take the request type
"CreateRoleRequest", both methods will be generated with the method name
"create_role", which causes generation to fail with an exception.

This commit resolves that issue by first generating a method name from
the request type of each method, and keeping track of which names are
duplicates. For methods that will generate a duplicate name from the
request type, the name is generated from the method ID instead (the
resulting name is guaranteed to be unique).