### PR TITLE
Handle recursive hashes

### DIFF
--- a/lib/google/apis/generator/model.rb
+++ b/lib/google/apis/generator/model.rb
@@ -55,8 +55,14 @@ module Google
             return 'Fixnum' if format == 'uint64'
             return TYPE_MAP[type]
           when 'array'
+            if items == self
+              return sprintf('Array<%s>', qualified_name)
+            end
             return sprintf('Array<%s>', items.generated_type)
           when 'hash'
+            if additional_properties == self
+              return sprintf('Hash<String,%s>', qualified_name)
+            end
             return sprintf('Hash<String,%s>', additional_properties.generated_type)
           when 'object'
             return qualified_name

--- a/lib/google/apis/generator/templates/_class.tmpl
+++ b/lib/google/apis/generator/templates/_class.tmpl
@@ -1,4 +1,4 @@
-<% if cls.type == 'object' -%>
+<% if cls.type == 'object' || (cls.type == 'hash' && cls.properties.length > 0) -%>
 
 # <%= block_comment(cls.description, 0, 1) %>
 class <%= cls.generated_class_name %><% if cls.base_ref %> < <%= cls.base_ref.generated_type %><% end %>


### PR DESCRIPTION
This fixes the generator for cases where one of the entries of the
"schemas" object returned by the Discovery service is a recursively
defined map.

Fixes #608 