### PR TITLE
Allow auth retry on Signet::AuthorizationError

### DIFF
--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -99,7 +99,7 @@ module Google
               # NotFound, etc
               auth_tries = (try == 1 && authorization_refreshable? ? 2 : 1)
               Retriable.retriable tries: auth_tries,
-                                  on: [Google::Apis::AuthorizationError],
+                                  on: [Google::Apis::AuthorizationError, Signet::AuthorizationError],
                                   on_retry: proc { |*| refresh_authorization } do
                 execute_once(client).tap do |result|
                   if block_given?


### PR DESCRIPTION
Fixes https://github.com/google/google-api-ruby-client/issues/554