### PR TITLE
Update version constraint 'googleauth'

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
-  spec.add_runtime_dependency 'googleauth', '~> 0.5'
+  spec.add_runtime_dependency 'googleauth', '~> 0.6'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'activesupport', '>= 4.2', '< 5.1'


### PR DESCRIPTION
This updates the version constraint of 'googleauth' so that we can use the latest version of that gem. This allows us to use the next major version (i.e. version 2.0) of the 'jwt' gem for which the version constraint was loosened in https://github.com/google/google-auth-library-ruby/pull/119.

Is there any particular reason to pin on a specific minor version, and not on a major version instead?