### PR TITLE
Improve language in Logging section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,23 +281,20 @@ GOOGLE_PRIVATE_KEY="YOUR GOOGLE DEVELOPER API KEY"
 
 The client includes a `Logger` instance that can be used to capture debugging information.
 
-To set the logging level for the client:
-
-```ruby
-Google::Apis.logger.level = Logger::DEBUG
-```
-
 When running in a Rails environment, the client will default to using `::Rails.logger`. If you
-prefer to use a separate logger instance for API calls, this can be changed via one of two ways.
-
-The first is to provide a new logger instance:
+prefer to use a separate logger instance for API calls, you can provide a new logger instance:
 
 ```ruby
 Google::Apis.logger = Logger.new(STDERR)
 ```
 
-The second is to set the environment variable `GOOGLE_API_USE_RAILS_LOGGER` to any value other than `'true'`
+Or, you can set the environment variable `GOOGLE_API_USE_RAILS_LOGGER` to any value other than `'true'`; this will send all logging information to STDOUT.
 
+To set the logging level for the client:
+
+```ruby
+Google::Apis.logger.level = Logger::DEBUG
+```
 
 ## Samples
 


### PR DESCRIPTION
For readers following the README's sequence of instructions to get logging to STDOUT/STDERR, they will generally add code in the order which it appears in the README. That results in this:
```
Google::Apis.logger.level = Logger::DEBUG
Google::Apis.logger = Logger.new(STDERR)
```

However, this configuration will not have the desired effect in Rails apps, since the newly created logger will not respect the log level which was actually set on the Rails logger. By changing the order in which these code snippets appear in the README, we can help readers avoid this gotcha.

Additionally, I offer a small semantic improvement to help readers better understand the two options they have for changing the default logger.