### PR TITLE
Add Ruby 2.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3.1
-  - 2.2.5
-  - 2.0.0
+  - 2.0
   - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - jruby
   - jruby-9.0.5.0
 env:
   - RAILS_VERSION="~>4.2.0"
@@ -12,7 +15,7 @@ env:
 matrix:
   exclude:
     - env: RAILS_VERSION="~>5.0.0"
-      rvm: 2.0.0
+      rvm: 2.0
     - env: RAILS_VERSION="~>5.0.0"
       rvm: 2.1
 before_install: gem install bundler

--- a/lib/google/apis/version.rb
+++ b/lib/google/apis/version.rb
@@ -21,7 +21,7 @@ module Google
     # @private
     OS_VERSION = begin
       if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/
-        `ver`.sub(/\s*\[Version\s*/, '/').sub(']', '').strip
+        `ver`.sub(/\s*\[Version\s*/, '/').sub(']', '')
       elsif RUBY_PLATFORM =~ /darwin/i
         "Mac OS X/#{`sw_vers -productVersion`}"
       elsif RUBY_PLATFORM == 'java'
@@ -31,7 +31,7 @@ module Google
         "#{name}/#{version}"
       else
         `uname -sr`.sub(' ', '/')
-      end
+      end.strip
     rescue
       RUBY_PLATFORM
     end

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe Google::Apis::Core::BaseService do
     expect(agent).to match /^test\/1.0/
   end
 
+  it 'should include os version in user agent' do
+    agent = service.send(:user_agent)
+    expect(agent).to match /#{Google::Apis::OS_VERSION}/
+  end
+
   it 'should inherit authorization' do
     Google::Apis::RequestOptions.default.authorization = 'a token'
     expect(service.authorization).to eql 'a token'

--- a/spec/google/apis/versions_spec.rb
+++ b/spec/google/apis/versions_spec.rb
@@ -1,0 +1,25 @@
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'google/apis/version'
+
+RSpec.describe Google::Apis::VERSION do
+  it { is_expected.to be_a(String) }
+
+  describe Google::Apis::OS_VERSION do
+    it { is_expected.to be_a(String) }
+    it { is_expected.not_to match /\n/ }
+  end
+end


### PR DESCRIPTION
Hi there!

Accordingly, to this commit https://github.com/ruby/ruby/commit/0078e40115fd53e2cafd4e8cfb6ff5fd7f87c3db, multiline headers are no more acceptable.  It's a pity, but the library generates `User-Agent`  with OS version which contains trailing newline. 

This PR solves the issue and add explicit Ruby 2.4 and 2.5 support to test against on CI.