### PR TITLE
Trim spaces & new line for OS_VERSION

### DIFF
--- a/lib/google/apis/version.rb
+++ b/lib/google/apis/version.rb
@@ -21,7 +21,7 @@ module Google
     # @private
     OS_VERSION = begin
       if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/
-        `ver`.sub(/\s*\[Version\s*/, '/').sub(']', '').strip
+        `ver`.sub(/\s*\[Version\s*/, '/').sub(']', '')
       elsif RUBY_PLATFORM =~ /darwin/i
         "Mac OS X/#{`sw_vers -productVersion`}"
       elsif RUBY_PLATFORM == 'java'
@@ -34,6 +34,6 @@ module Google
       end
     rescue
       RUBY_PLATFORM
-    end
+    end.strip
   end
 end


### PR DESCRIPTION
Sometimes os_systems adds new_line symbol to OS name. as a result google client has ENV::OS_VERSION with \n symbol (for some mac & linux). 
So that it's impossible to use client because of error.
```
ArgumentError (header field value cannot include CR/LF):
```
Also described here https://github.com/google/google-api-ruby-client/issues/645 

Example from my OS: 
```
[23] pry(#<Google::APIClient>)> "Mac OS X/#{`sw_vers -productVersion`}"
=> "Mac OS X/10.13.3\n"

```
@googleapis-publisher So can we get this merged? 