### PR TITLE
WIP: Change IPv4 to Ipv4 before interpetting it as camel case.

### DIFF
--- a/lib/google/apis/generator/helpers.rb
+++ b/lib/google/apis/generator/helpers.rb
@@ -37,7 +37,9 @@ module Google
         # @param [String] name
         # @return [String] updated param name
         def normalize_param_name(name)
-          name = ActiveSupport::Inflector.underscore(name.gsub(/\W/, '_'))
+          name = name.gsub(/\W/, '_')
+          name = name.gsub(/IPv4/, 'Ipv4')
+          name = ActiveSupport::Inflector.underscore(name)
           if reserved?(name)
             logger.warn { sprintf('Found reserved keyword \'%1$s\'', name) }
             name += '_'


### PR DESCRIPTION
I found the bug, I am not familiar enough Ruby to make the fix idiomatic and I haven't looked for other acronym edge cases yet.
CC @Temikus