### PR TITLE
Add support for COURSE_WORK_CHANGES for google classroom feed

### DIFF
--- a/generated/google/apis/classroom_v1/classes.rb
+++ b/generated/google/apis/classroom_v1/classes.rb
@@ -515,6 +515,25 @@ module Google
           @course_id = args[:course_id] if args.key?(:course_id)
         end
       end
+
+      # Information about a `Feed` with a `feed_type` of `COURSE_WORK_CHANGES`.
+      class CourseWorkChangesInfo
+        include Google::Apis::Core::Hashable
+      
+        # The `course_id` of the course to subscribe to course work changes for.
+        # Corresponds to the JSON property `courseId`
+        # @return [String]
+        attr_accessor :course_id
+      
+        def initialize(**args)
+           update!(**args)
+        end
+      
+        # Update properties of this object
+        def update!(**args)
+          @course_id = args[:course_id] if args.key?(:course_id)
+        end
+      end
       
       # Course work created by a teacher for students of the course.
       class CourseWork
@@ -828,6 +847,10 @@ module Google
         # Corresponds to the JSON property `courseRosterChangesInfo`
         # @return [Google::Apis::ClassroomV1::CourseRosterChangesInfo]
         attr_accessor :course_roster_changes_info
+        # Information about a `Feed` with a `feed_type` of `COURSE_WORK_CHANGES`.
+        # Corresponds to the JSON property `courseWorkChangesInfo`
+        # @return [Google::Apis::ClassroomV1::CourseWorkChangesInfo]
+        attr_accessor :course_work_changes_info
       
         # The type of feed.
         # Corresponds to the JSON property `feedType`
@@ -841,6 +864,7 @@ module Google
         # Update properties of this object
         def update!(**args)
           @course_roster_changes_info = args[:course_roster_changes_info] if args.key?(:course_roster_changes_info)
+          @course_work_changes_info = args[:course_work_changes_info] if args.key?(:course_work_changes_info)
           @feed_type = args[:feed_type] if args.key?(:feed_type)
         end
       end

--- a/generated/google/apis/classroom_v1/representations.rb
+++ b/generated/google/apis/classroom_v1/representations.rb
@@ -81,6 +81,12 @@ module Google
       
         include Google::Apis::Core::JsonObjectSupport
       end
+
+      class CourseWorkChangesInfo
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+      
+        include Google::Apis::Core::JsonObjectSupport
+      end
       
       class CourseWork
         class Representation < Google::Apis::Core::JsonRepresentation; end
@@ -472,6 +478,13 @@ module Google
       end
       
       class CourseRosterChangesInfo
+        # @private
+        class Representation < Google::Apis::Core::JsonRepresentation
+          property :course_id, as: 'courseId'
+        end
+      end
+
+      class CourseWorkChangesInfo
         # @private
         class Representation < Google::Apis::Core::JsonRepresentation
           property :course_id, as: 'courseId'

--- a/generated/google/apis/classroom_v1/representations.rb
+++ b/generated/google/apis/classroom_v1/representations.rb
@@ -562,6 +562,7 @@ module Google
         # @private
         class Representation < Google::Apis::Core::JsonRepresentation
           property :course_roster_changes_info, as: 'courseRosterChangesInfo', class: Google::Apis::ClassroomV1::CourseRosterChangesInfo, decorator: Google::Apis::ClassroomV1::CourseRosterChangesInfo::Representation
+          property :course_work_changes_info, as: 'courseWorkChangesInfo', class: Google::Apis::ClassroomV1::CourseWorkChangesInfo, decorator: Google::Apis::ClassroomV1::CourseWorkChangesInfo::Representation
       
           property :feed_type, as: 'feedType'
         end


### PR DESCRIPTION
Fix for issue [#704](https://github.com/google/google-api-ruby-client/issues/704)

There was no support for Feed type COURSE_WORK_CHANGES as mentioned here : https://developers.google.com/classroom/reference/rest/v1/registrations#FeedType

Added support for that by creating class `CourseWorkChangesInfo` and supporting attribute `course_work_changes_info` for class `Feed`