### PR TITLE
Add logging to gemfile to fix specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ specdoc
 wiki
 .google-api.yaml
 *.log
+tmp/
 
 #IntelliJ
 .idea

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   gem 'os', '~> 0.9'
   gem 'rmail', '~> 1.1'
   gem 'redis', '~> 3.2'
+  gem 'logging', '~> 2.2'
 end
 
 platforms :jruby do

--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -99,7 +99,7 @@ module Google
               # NotFound, etc
               auth_tries = (try == 1 && authorization_refreshable? ? 2 : 1)
               Retriable.retriable tries: auth_tries,
-                                  on: [Google::Apis::AuthorizationError, Signet::AuthorizationError],
+                                  on: [Google::Apis::AuthorizationError, Signet::AuthorizationError, Signet::RemoteServerError],
                                   on_retry: proc { |*| refresh_authorization } do
                 execute_once(client).tap do |result|
                   if block_given?

--- a/spec/google/apis/generator/generator_spec.rb
+++ b/spec/google/apis/generator/generator_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe Google::Apis::Generator do
       generator = Google::Apis::Generator.new(api_names: File.join(FIXTURES_DIR, 'files', 'api_names.yaml'))
       discovery = File.read(File.join(FIXTURES_DIR, 'files', 'test_api.json'))
       generated_files = generator.render(discovery)
-      puts generator.dump_api_names
+      # puts generator.dump_api_names
       tempdir = Dir.mktmpdir
       generated_files.each do |key, content|
-        puts content
+        # puts content
         path = File.join(tempdir, key)
         FileUtils.mkdir_p(File.dirname(path))
         File.open(path, 'w') do |f|


### PR DESCRIPTION
It looks like the logging gem used to be in the bundle implicitly due to a transitive dependency, but has been removed. This is why the tests have been breaking. Adding it explicitly because the spec helper requires it.