### PR TITLE
update signet dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.7
+* Backwards compatible changes:
+  * Make dependency on signet explicit and with correct version
+
 # 0.23.6
 * Backwards compatible changes:
   * Added `jobs_v3`

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
-  spec.add_runtime_dependency 'signet', '~> 0.9.0'
+  spec.add_runtime_dependency 'signet', '~> 0.9'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.7.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.version       = Google::Apis::VERSION
   spec.authors       = ['Steven Bazyl', 'Tim Emiola', 'Sergio Gomes', 'Bob Aman']
   spec.email         = ['sbazyl@google.com']
-  spec.summary       = %q{Client for accessing Google APIs}
+  spec.summary       = 'Client for accessing Google APIs'
   spec.homepage      = 'https://github.com/google/google-api-ruby-client'
   spec.license       = 'Apache-2.0'
 
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
                        .reject { |f| f.match(%r{^(spec|script)/|^api_names_out}) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib', 'generated', 'third_party']
+  spec.require_paths = %w[lib generated third_party]
 
   spec.required_ruby_version = '~> 2.0'
 
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
+  spec.add_runtime_dependency 'signet', '~> 9.0'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.7.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
-  spec.add_runtime_dependency 'signet', '~> 9.0'
+  spec.add_runtime_dependency 'signet', '~> 0.9.0'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.7.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'

--- a/lib/google/apis/version.rb
+++ b/lib/google/apis/version.rb
@@ -15,7 +15,7 @@
 module Google
   module Apis
     # Client library version
-    VERSION = '0.23.6'
+    VERSION = '0.23.7'.freeze
 
     # Current operating system
     # @private


### PR DESCRIPTION
* Fix for https://github.com/google/google-api-ruby-client/issues/708
* Makes runtime dependency on signet explicit with correct version